### PR TITLE
fix issues related to dirty state on load

### DIFF
--- a/app/src/components/App.tsx
+++ b/app/src/components/App.tsx
@@ -8,14 +8,14 @@ import EditLLMs from './EditLLMs'
 
 function App() {
   return (
-    <ChainSpecProvider>
-      <LLMContextProvider>
+    <LLMContextProvider>
+      <ChainSpecProvider>
         <Header />
         <Designer />
         <Interaction />
         <EditLLMs />
-      </LLMContextProvider>
-    </ChainSpecProvider>
+      </ChainSpecProvider>
+    </LLMContextProvider>
   )
 }
 

--- a/app/src/components/Designer.tsx
+++ b/app/src/components/Designer.tsx
@@ -34,7 +34,7 @@ const LLMSpecDesigner = ({ spec, updateChainSpec }: LLMSpecDesignerProps) => {
       variables.add(variable),
       `<span class="expr">{<span class="var-name">${variable}</span>}</span>`
     ],
-    (variables: Set<string>) => setVariables(Array.from(variables))
+    (variables: Set<string>) => setTimeout(() => setVariables(Array.from(variables)), 0)
   ), []);
 
   useEffect(() => {

--- a/app/src/components/EditLLMs.tsx
+++ b/app/src/components/EditLLMs.tsx
@@ -21,7 +21,6 @@ const OpenAILLMEditor = ({ llmKey, llm, updateLLM }: OpenAILLMEditorProps) => {
 
   useEffect((): void => {
     updateLLM(name, { 
-      _type: 'openai',
       model_name: modelName,
       temperature: temperature,
       max_tokens: maxTokens,
@@ -32,6 +31,7 @@ const OpenAILLMEditor = ({ llmKey, llm, updateLLM }: OpenAILLMEditorProps) => {
       best_of: 1,
       request_timeout: null,
       logit_bias: {},
+      _type: 'openai',
     });
   }, [name, modelName, temperature, maxTokens, topP, frequencyPenalty, presencePenalty]);
 

--- a/app/src/model/spec_control.ts
+++ b/app/src/model/spec_control.ts
@@ -91,23 +91,23 @@ export const computeChainIO = (spec: ChainSpec): [Set<string>, Set<string>] => {
   }
 }
 
-const updateChildren = (spec: ChainSpec) => {
+export const updateChildIO = (spec: ChainSpec) => {
   switch (spec.chain_type) {
     case 'sequential_spec':
-      spec.chains.forEach(updateChildren);
+      spec.chains.forEach(updateChildIO);
       const [inKeys, outKeys] = computeChainIO(spec);
       spec.input_keys = Array.from(inKeys);
       spec.output_keys = Array.from(outKeys);
       return;
     case 'case_spec':
-      Object.values(spec.cases).forEach(updateChildren);
-      if (spec.default_case) updateChildren(spec.default_case);
+      Object.values(spec.cases).forEach(updateChildIO);
+      if (spec.default_case) updateChildIO(spec.default_case);
       return;
   }
 }
 
 export const createRevision = (parent: string | null, chain: ChainSpec, llms: Record<string,any>): Revision => {
-  updateChildren(chain);
+  updateChildIO(chain);
   return { parent, chain, llms }
 }
 


### PR DESCRIPTION
## Problem

We would like testbench to be in the ready to interact state when we load a chain. That is we expect it not to be in the dirty state. We would also like changes to the LLMs to put the app in the dirty state so that we can save the chain. There were several bugs and omissions that prevented us from correctly tracking the dirty state.

## Solution

1. Add logic to test whether LLMs have been updated.
2. Use the above to put the app in the dirty state when LLMs have been updated.
3. Wait a frame when updating LLM variables to ensure they trigger the useEffect that updates the dirty spec.
4. Match the order of LLM parameters between default and updates so that JSON.stringify matching works.
5. Update Huggingface  LLM interface to eliminate errors.