### PR TITLE
delete spec from chain

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@ TODO:
 * Bug: Loding revision does not necessarily put it in the readyToInteract state.
 
 * UI shouldn't be editable until a new branch name is created or an existing one is loaded.
-* Add the ability to delete chains.
 * Validation (e.g. case must have categorization_key)
 * Add UI to view output from each response
 * Recording.

--- a/app/src/components/Designer.tsx
+++ b/app/src/components/Designer.tsx
@@ -17,7 +17,7 @@ const specTypeOptions = {
   api_spec: 'API',
 };
 
-const DeleteComponent = ({ onDelete }: { onDelete: () => void }) => <QuickMenu
+const DeleteChainButton = ({ onDelete }: { onDelete: () => void }) => <QuickMenu
   menuClass="delete-spec"
   options={{ cancel: 'cancel', delete: 'delete' }}
   selectValue={(option: string) => {if (option === 'delete') onDelete()}}
@@ -62,7 +62,7 @@ const LLMSpecDesigner = ({ spec }: LLMSpecDesignerProps) => {
   return (
     <div className="llm-spec spec-designer">
       <h3 className="chain-id">LLM {spec.chain_id}</h3>
-      <DeleteComponent onDelete={() => deleteChainSpec(spec.chain_id)}/>
+      <DeleteChainButton onDelete={() => deleteChainSpec(spec.chain_id)}/>
       <HighlightedTextarea
         value={prompt}
         onChange={setPrompt}
@@ -90,7 +90,7 @@ const SequentialSpecDesigner = ({ spec }: SequentialSpecDesignerProps) => {
   return (
     <div className="sequential-spec spec-designer">
       <h3 className="chain-id">Sequential {spec.chain_id}</h3>
-      <DeleteComponent onDelete={() => deleteChainSpec(spec.chain_id)}/>
+      <DeleteChainButton onDelete={() => deleteChainSpec(spec.chain_id)}/>
       <QuickMenu selectValue={(option) => insertChainSpec(option, spec.chain_id, 0)} options={specTypeOptions} />
       {spec.chains.flatMap((chain: ChainSpec, idx: number) => [
         renderChainSpec(chain),
@@ -149,7 +149,7 @@ const CaseSpecDesigner = ({ spec }: CaseSpecDesignerProps) => {
   return (
     <div className="case-spec spec-designer">
       <h3 className="chain-id">Case {spec.chain_id}</h3>
-      <DeleteComponent onDelete={() => deleteChainSpec(spec.chain_id)}/>
+      <DeleteChainButton onDelete={() => deleteChainSpec(spec.chain_id)}/>
       <div className="form-element">
         <label>Category Key</label>
         <input className="var-name-input" value={categorizationKey} onChange={e => setCategorizationKey(e.target.value)} />
@@ -259,7 +259,7 @@ const ReformatSpecDesigner = ({ spec }: ReformatSpecDesignerProps) => {
   return (
     <div className="reformat-spec spec-designer">
       <h3 className="chain-id">Reformat {spec.chain_id}</h3>
-      <DeleteComponent onDelete={() => deleteChainSpec(spec.chain_id)}/>
+      <DeleteChainButton onDelete={() => deleteChainSpec(spec.chain_id)}/>
       <div className="formatters">
         { formatters.map(([key, value], idx) => (
           <div className="formatter form-element" key={`reformat-${idx}`}>
@@ -335,7 +335,7 @@ const APISpecDesigner = ({ spec }: APISpecDesignerProps) => {
   return (
     <div className="api-spec spec-designer">
       <h3 className="chain-id">API {spec.chain_id}</h3>
-      <DeleteComponent onDelete={() => deleteChainSpec(spec.chain_id)}/>
+      <DeleteChainButton onDelete={() => deleteChainSpec(spec.chain_id)}/>
       <div className="form-element">
         <label>URL</label>
         <input className="text-input" value={url} onChange={e => setUrl(e.target.value)} placeholder="URL" />

--- a/app/src/components/Designer.tsx
+++ b/app/src/components/Designer.tsx
@@ -1,15 +1,13 @@
 import { useCallback, useContext, useState, useEffect, useMemo } from "react";
 import { LLMSpec, SequentialSpec, CaseSpec, ReformatSpec, APISpec, ChainSpec } from '../model/specs';
 import QuickMenu from "./QuickMenu";
-import ChainSpecContext, { UpdateSpecFunc } from "../contexts/ChainSpecContext";
+import ChainSpecContext from "../contexts/ChainSpecContext";
 import HighlightedTextarea from "./HighlightedTextarea";
 import FormatReducer from "../util/FormatReducer";
 import "./style/Designer.css"
 import { LLMContext } from "../contexts/LLMContext";
 
-type InsertChainFunc = (type: string, chainId: number, index: number) => void;
-
-interface LLMSpecDesignerProps { spec: LLMSpec, updateChainSpec: UpdateSpecFunc };
+interface LLMSpecDesignerProps { spec: LLMSpec };
 
 const specTypeOptions = {
   llm_spec: 'LLM',
@@ -19,8 +17,15 @@ const specTypeOptions = {
   api_spec: 'API',
 };
 
-const LLMSpecDesigner = ({ spec, updateChainSpec }: LLMSpecDesignerProps) => {
+const DeleteComponent = ({ onDelete }: { onDelete: () => void }) => <QuickMenu
+  menuClass="delete-spec"
+  options={{ cancel: 'cancel', delete: 'delete' }}
+  selectValue={(option: string) => {if (option === 'delete') onDelete()}}
+  buttonText="x"/>
+
+const LLMSpecDesigner = ({ spec }: LLMSpecDesignerProps) => {
   const { llms } = useContext(LLMContext);
+  const { updateChainSpec, deleteChainSpec } = useContext(ChainSpecContext);
 
   const [prompt, setPrompt] = useState<string>(spec.prompt);
   const [outputKey, setOutputKey] = useState<string>(spec.output_key);
@@ -57,6 +62,7 @@ const LLMSpecDesigner = ({ spec, updateChainSpec }: LLMSpecDesignerProps) => {
   return (
     <div className="llm-spec spec-designer">
       <h3 className="chain-id">LLM {spec.chain_id}</h3>
+      <DeleteComponent onDelete={() => deleteChainSpec(spec.chain_id)}/>
       <HighlightedTextarea
         value={prompt}
         onChange={setPrompt}
@@ -77,25 +83,27 @@ const LLMSpecDesigner = ({ spec, updateChainSpec }: LLMSpecDesignerProps) => {
   );
 };
 
-interface SequentialSpecDesignerProps { spec: SequentialSpec, insertChain: InsertChainFunc, updateChainSpec: UpdateSpecFunc };
+interface SequentialSpecDesignerProps { spec: SequentialSpec };
 
-const SequentialSpecDesigner = ({ spec, insertChain, updateChainSpec }: SequentialSpecDesignerProps) => {
+const SequentialSpecDesigner = ({ spec }: SequentialSpecDesignerProps) => {
+  const { insertChainSpec, deleteChainSpec } = useContext(ChainSpecContext);
   return (
     <div className="sequential-spec spec-designer">
       <h3 className="chain-id">Sequential {spec.chain_id}</h3>
-      <QuickMenu selectValue={(option) => insertChain(option, spec.chain_id, 0)} options={specTypeOptions} />
+      <DeleteComponent onDelete={() => deleteChainSpec(spec.chain_id)}/>
+      <QuickMenu selectValue={(option) => insertChainSpec(option, spec.chain_id, 0)} options={specTypeOptions} />
       {spec.chains.flatMap((chain: ChainSpec, idx: number) => [
-        renderChainSpec(chain, insertChain, updateChainSpec),
-        <QuickMenu selectValue={(option) => insertChain(option, spec.chain_id, idx+1)} options={specTypeOptions} key={`button-${idx+1}`}/>
+        renderChainSpec(chain),
+        <QuickMenu selectValue={(option) => insertChainSpec(option, spec.chain_id, idx+1)} options={specTypeOptions} key={`button-${idx+1}`}/>
       ])}
     </div>
   );
 };
 
-interface CaseSpecDesignerProps { spec: CaseSpec, insertChain: InsertChainFunc, updateChainSpec: UpdateSpecFunc };
+interface CaseSpecDesignerProps { spec: CaseSpec };
 
-const CaseSpecDesigner = ({ spec, insertChain, updateChainSpec }: CaseSpecDesignerProps) => {
-  const { findByChainId } = useContext(ChainSpecContext);
+const CaseSpecDesigner = ({ spec }: CaseSpecDesignerProps) => {
+  const { deleteChainSpec, findByChainId, insertChainSpec, updateChainSpec } = useContext(ChainSpecContext);
   const [categorizationKey, setCategorizationKey] = useState<string>(spec.categorization_key);
   const [cases, setCases] = useState<[string, ChainSpec][]>([]);
 
@@ -141,17 +149,18 @@ const CaseSpecDesigner = ({ spec, insertChain, updateChainSpec }: CaseSpecDesign
   return (
     <div className="case-spec spec-designer">
       <h3 className="chain-id">Case {spec.chain_id}</h3>
+      <DeleteComponent onDelete={() => deleteChainSpec(spec.chain_id)}/>
       <div className="form-element">
         <label>Category Key</label>
         <input className="var-name-input" value={categorizationKey} onChange={e => setCategorizationKey(e.target.value)} />
       </div>
-      <QuickMenu selectValue={(option) => insertChain(option, spec.chain_id, 0)} options={specTypeOptions} />
+      <QuickMenu selectValue={(option) => insertChainSpec(option, spec.chain_id, 0)} options={specTypeOptions} />
       {cases.flatMap((item: [string, ChainSpec], idx: number) => [
         <div className="case-spec-case" key={`spec-case-${item[1].chain_id}`}>
           <input className="case-spec-case__key" defaultValue={item[0]} onChange={(e) => updateCaseKey(idx, e.target.value)} />
-          {renderChainSpec(item[1] as ChainSpec, insertChain, updateChainSpec)}
+          {renderChainSpec(item[1] as ChainSpec)}
         </div>,
-        <QuickMenu selectValue={(option) => insertChain(option, spec.chain_id, idx+1)} options={specTypeOptions} key={`button-${idx+1}`}/>,
+        <QuickMenu selectValue={(option) => insertChainSpec(option, spec.chain_id, idx+1)} options={specTypeOptions} key={`button-${idx+1}`}/>,
       ])}
     </div>
   );
@@ -211,9 +220,10 @@ const extendedFormatterReduceFunc = (
   return [[newInputs, newInternal], '<span class="error">ERROR</span>'];
 }
 
-interface ReformatSpecDesignerProps { spec: ReformatSpec, updateChainSpec: UpdateSpecFunc  };
+interface ReformatSpecDesignerProps { spec: ReformatSpec  };
 
-const ReformatSpecDesigner = ({ spec, updateChainSpec }: ReformatSpecDesignerProps) => {
+const ReformatSpecDesigner = ({ spec }: ReformatSpecDesignerProps) => {
+  const { deleteChainSpec, updateChainSpec } = useContext(ChainSpecContext);
   const [formatters, setFormatters] = useState<[string, string][]>([]);
   const [variables, setVariables] = useState<string[]>([]);
 
@@ -249,6 +259,7 @@ const ReformatSpecDesigner = ({ spec, updateChainSpec }: ReformatSpecDesignerPro
   return (
     <div className="reformat-spec spec-designer">
       <h3 className="chain-id">Reformat {spec.chain_id}</h3>
+      <DeleteComponent onDelete={() => deleteChainSpec(spec.chain_id)}/>
       <div className="formatters">
         { formatters.map(([key, value], idx) => (
           <div className="formatter form-element" key={`reformat-${idx}`}>
@@ -272,9 +283,11 @@ const ReformatSpecDesigner = ({ spec, updateChainSpec }: ReformatSpecDesignerPro
   );
 };
 
-interface APISpecDesignerProps { spec: APISpec, updateChainSpec: UpdateSpecFunc };
+interface APISpecDesignerProps { spec: APISpec };
 
-const APISpecDesigner = ({ spec, updateChainSpec }: APISpecDesignerProps) => {
+const APISpecDesigner = ({ spec }: APISpecDesignerProps) => {
+  const { deleteChainSpec, updateChainSpec } = useContext(ChainSpecContext);
+
   const [url, setUrl] = useState<string>(spec.url);
   const [method, setMethod] = useState<string>(spec.method);
   const [headers, setHeaders] = useState<string>(JSON.stringify(spec.headers, null, 2));
@@ -322,6 +335,7 @@ const APISpecDesigner = ({ spec, updateChainSpec }: APISpecDesignerProps) => {
   return (
     <div className="api-spec spec-designer">
       <h3 className="chain-id">API {spec.chain_id}</h3>
+      <DeleteComponent onDelete={() => deleteChainSpec(spec.chain_id)}/>
       <div className="form-element">
         <label>URL</label>
         <input className="text-input" value={url} onChange={e => setUrl(e.target.value)} placeholder="URL" />
@@ -352,28 +366,28 @@ const APISpecDesigner = ({ spec, updateChainSpec }: APISpecDesignerProps) => {
   );
 };
 
-const renderChainSpec = (spec: ChainSpec, insertChain: InsertChainFunc, updateSpec: UpdateSpecFunc) => {
+const renderChainSpec = (spec: ChainSpec) => {
   switch (spec.chain_type) {
     case "llm_spec":
-      return <LLMSpecDesigner spec={spec} updateChainSpec={updateSpec} key={`llm-spec-${spec.chain_id}`} />;
+      return <LLMSpecDesigner spec={spec} key={`llm-spec-${spec.chain_id}`} />;
     case "sequential_spec":
-      return <SequentialSpecDesigner spec={spec} updateChainSpec={updateSpec} insertChain={insertChain} key={`sequential-spec-${spec.chain_id}`} />;
+      return <SequentialSpecDesigner spec={spec} key={`sequential-spec-${spec.chain_id}`} />;
     case "case_spec":
-      return <CaseSpecDesigner spec={spec} updateChainSpec={updateSpec} insertChain={insertChain} key={`case-spec-${spec.chain_id}`} />;
+      return <CaseSpecDesigner spec={spec} key={`case-spec-${spec.chain_id}`} />;
     case "reformat_spec":
-      return <ReformatSpecDesigner spec={spec} updateChainSpec={updateSpec} key={`reformat-spec-${spec.chain_id}`}/>;
+      return <ReformatSpecDesigner spec={spec} key={`reformat-spec-${spec.chain_id}`}/>;
     case "api_spec":
-      return <APISpecDesigner spec={spec} updateChainSpec={updateSpec} key={`api-spec-${spec.chain_id}`}/>;
+      return <APISpecDesigner spec={spec} key={`api-spec-${spec.chain_id}`}/>;
   }
 };
 
 const Designer = () => {
-  const { chainSpec: spec, insertChainSpec, updateChainSpec, isInteracting } = useContext(ChainSpecContext);
+  const { chainSpec: spec, insertChainSpec, isInteracting } = useContext(ChainSpecContext);
 
   return (
     <div className={`designer ${isInteracting ? 'interacting' : ''}`}>
       { spec 
-        ? renderChainSpec(spec, insertChainSpec, updateChainSpec)
+        ? renderChainSpec(spec)
         : <QuickMenu selectValue={(option) => insertChainSpec(option, 0, 0)} options={specTypeOptions}/> 
       }
     </div>

--- a/app/src/components/QuickMenu.tsx
+++ b/app/src/components/QuickMenu.tsx
@@ -4,9 +4,14 @@ import "./style/QuickMenu.css";
 interface QuickMenuProps {
   options: Record<string, string>;
   selectValue: (option: string) => void;
+  buttonText?: string;
+  menuClass?: string;
 }
-const QuickMenu = ({selectValue, options}: QuickMenuProps) => {
+const QuickMenu = ({selectValue, options, buttonText, menuClass }: QuickMenuProps) => {
   const [modalOpen, setModalOpen] = useState(false);
+
+  buttonText = buttonText || '+';
+  menuClass = menuClass || '';
 
   const handleInsert = (option: string) => {
     setModalOpen(false);
@@ -14,8 +19,8 @@ const QuickMenu = ({selectValue, options}: QuickMenuProps) => {
   }
 
   return (
-    <div className={`quick-menu ${modalOpen ? 'open' : ''}`}>
-      <button onClick={()=>setModalOpen(!modalOpen)} className="open-quick-menu">{modalOpen ? 'x' : '+'}</button>
+    <div className={`quick-menu ${modalOpen ? 'open' : ''} ${menuClass}`}>
+      <button onClick={()=>setModalOpen(!modalOpen)} className='open-quick-menu'>{modalOpen ? 'x' : buttonText}</button>
       <div className="quick-menu-selector">
         {
           Object.entries(options).map(([key, value], idx) => (

--- a/app/src/components/style/Designer.css
+++ b/app/src/components/style/Designer.css
@@ -205,3 +205,23 @@
   padding: .8rem 1rem;
   font-size: .75rem;
 }
+
+.designer .delete-spec {
+  position: absolute;
+  right: 0;
+  top: 0;
+  height: 2em;
+  margin: 0;
+  padding: .4rem .4rem;
+  font-size: .75rem;
+}
+
+.designer .delete-spec .open-quick-menu {
+  width: 1.5rem;
+  height: 1.5rem;
+  line-height: 1.5rem;
+}
+
+.designer .delete-spec .quick-menu-selector {
+  top: 0;
+}

--- a/app/src/contexts/LLMContext.tsx
+++ b/app/src/contexts/LLMContext.tsx
@@ -86,7 +86,7 @@ export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => 
           task: null,
           model_kwargs: {
             temperature: 0.8,
-            max_new_tokens: 256,
+            max_length: 256,
             min_new_tokens: 128,
             max_time: 60,
           },

--- a/app/src/model/llm.ts
+++ b/app/src/model/llm.ts
@@ -14,9 +14,9 @@ export interface OpenAILLM {
 
 export interface HuggingFaceHubArgs {
   temperature: number;
-  max_new_tokens: number;
-  min_new_tokens: number;
-  max_time: number;
+  max_length: number;
+  min_new_tokens?: number;
+  max_time?: number;
 }
 
 export interface HuggingFaceHubLLM {

--- a/app/src/model/specs.ts
+++ b/app/src/model/specs.ts
@@ -22,7 +22,7 @@ export interface CaseSpec extends BaseSpec {
   chain_type: "case_spec";
   cases: Record<string, ChainSpec>;
   categorization_key: string;
-  default_case: ChainSpec;
+  default_case: ChainSpec | null;
 }
 
 export interface ReformatSpec extends BaseSpec {


### PR DESCRIPTION
## Problem

Once a child chain is added to a chain in the designer, there is no way to remove it. This greatly limits one's ability to edit chains. This PR adds delete function.

## Solution

1. Modify QuickMenu so that it that it supports custom button text and a custom class.
2. Create DeleteChainButton component from QuickMenu
3. Add DeleteChainButton components to all chain designer components and wire them to call `deleteChainSpec`.
4. Implement `deleteChainSpec` to remove a chain from the designer.
5. Refactor Designer components to pull update and insert functions from context rather than accepting them as parameters.