### PR TITLE
fix issues with case chain during insertion and updating

### DIFF
--- a/app/src/model/spec_control.ts
+++ b/app/src/model/spec_control.ts
@@ -202,7 +202,7 @@ export const insertChainSpec = (
             key,
             insertChainSpec(chain, nextChainId, type, chainId, index)
           ])),
-          default_case: insertChainSpec(originalSpec.default_case, nextChainId, type, chainId, index)
+          default_case: originalSpec.default_case ? insertChainSpec(originalSpec.default_case, nextChainId, type, chainId, index) : null,
         }
       }
   }
@@ -285,9 +285,7 @@ export const updateChainSpec = (
         : updateChainSpec(chainSpec, newSubSpec);
       return {
         found: nextResult.found,
-        chainSpecs: nextResult.found
-          ? [...result.chainSpecs, [key, nextResult.chainSpec]]
-          : result.chainSpecs
+        chainSpecs: [...result.chainSpecs, [key, nextResult.found ? nextResult.chainSpec : chainSpec]]
       } as UpdateCaseResult;
     }, { found: false, chainSpecs: [] as [string, ChainSpec][] });
 


### PR DESCRIPTION
## Problem

There were two problems with case chains:

1. When the case chain lacks a `_default` chain, but contains a sequential or case chain as a case, adding a chain to the subchain will create a duplicate chain as the `_default`. This is because it always attempts to insert into the default chain in this case, but inserting into a null chain always inserts.
2. When adding multiple cases to the case chain, some of those cases may disappear prior to saving. This was caused by the update failing to fully regenerate the CaseChain's cases under some circumstances.

## Solution

1. Bypass the insert process if the _default chain is null.
2. Always add all the cases during update.