### PR TITLE
support escaped brackets in formatters and fix highlighted spaces

### DIFF
--- a/app/src/components/Designer.tsx
+++ b/app/src/components/Designer.tsx
@@ -33,12 +33,13 @@ const LLMSpecDesigner = ({ spec }: LLMSpecDesignerProps) => {
   const [llm, setLLM] = useState<string>(spec.llm_key);
 
   const formatReducer = useMemo(() => new FormatReducer(
-    /{(.*?)}/g,
+    /(\{\{)|\{(.*?)\}/g,
     () => new Set<string>(),
-    (variables: Set<string>, _, variable) => [
+    (variables: Set<string>, _, escape, variable) => (
+      escape ? [variables, escape] : [
       variables.add(variable),
       `<span class="expr">{<span class="var-name">${variable}</span>}</span>`
-    ],
+    ]),
     (variables: Set<string>) => setTimeout(() => setVariables(Array.from(variables)), 0)
   ), []);
 
@@ -169,7 +170,7 @@ const CaseSpecDesigner = ({ spec }: CaseSpecDesignerProps) => {
 
 type ExtendedFormatterState = [inputs: Set<string>, internal: Set<string>];
 
-const extendedFormatterRegex = /\{(join|parse_json|let|expr|int|float):([^:\{\}]+)(:([^:\{\}]+))?\}|(\{([^\{\}]*)\})/g;
+const extendedFormatterRegex = /(\{\{)|\{(join|parse_json|let|expr|int|float):([^:\{\}]+)(:([^:\{\}]+))?\}|(\{([^\{\}]*)\})/g;
 const parseFormatExpression = (expr: string): [string, string] => {
   const variable = expr.match(/^[_A-Za-z0-9]+/)?.[0] || '';
   return [variable, expr.slice(variable.length)];
@@ -181,6 +182,7 @@ const condAdd = (set1: Set<string>, set2: Set<string>, item: string): Set<string
 const extendedFormatterReduceFunc = (
   [inputs, internal]: ExtendedFormatterState,
   _: string,
+  escape: string | undefined,
   exprType: string | undefined,
   exprParam1: string | undefined,
   _ep2Group: string | undefined,
@@ -188,6 +190,8 @@ const extendedFormatterReduceFunc = (
   stdExpr: string | undefined,
   stdExprVar: string | undefined,
 ): [ExtendedFormatterState, string] => {
+  if (escape) return [[inputs, internal], escape];
+
   const [newInputs, newInternal] = [new Set(inputs), new Set(internal)];
   if (exprType === 'parse_json' || exprType === 'let' || exprType === 'int' || exprType === 'float') {
     const [variable, expr] = parseFormatExpression(exprParam1 || '');

--- a/app/src/util/html.ts
+++ b/app/src/util/html.ts
@@ -5,10 +5,10 @@ const htmlEscapes: Record<string, string> = {
   '&': '&amp;',
   '"': '&quot;',
   "'": '&#39;',
-  '\n': '<br/>'
+  '\n': '<br/>',
 }
 
 export const escapeHTML = (str: string) => str
   .replace(/[<>\n&"']/g, (m) => htmlEscapes[m]) // escape special characters
+  .replace(/(^|\<br\/\>| )( +)/g, (_, p, s) => p + s.replace(/./g, '&nbsp;')) // extra spaces become non-breaking spaces
   .replace(/<br\/>$/, "<br/><br/>")             // add extra line break at end of string
-  .replace(/  /g, " &nbsp;")                    // replace double spaces with non-breaking space


### PR DESCRIPTION
## Problem

The primary problem is that both FormatReducers (for LLMSpec and ReformatSpec) treat all braces as format expressions. This makes it impossible to write JSON, which is bad because LLMs can do really interesting things with JSON.

The second problem is that HTML ignores spaces at the beginning of a line or after a <br/> tag. This causes a misalignment of the input caret.

## Solution

1. Modify the regular expressions of both format reducers to catch '{{' first.
2. Modify handler to do nothing special when the escape above is discovered.
3. Modify `escapeHTML` to convert the first space or the first space after a new line to an &nbsp;.