### PR TITLE
Fix dirty state issues

### DIFF
--- a/app/src/components/Designer.tsx
+++ b/app/src/components/Designer.tsx
@@ -30,7 +30,7 @@ const LLMSpecDesigner = ({ spec }: LLMSpecDesignerProps) => {
 
   const [prompt, setPrompt] = useState<string>(spec.prompt);
   const [outputKey, setOutputKey] = useState<string>(spec.output_key);
-  const [variables, setVariables] = useState<string[]>([]);
+  const [variables, setVariables] = useState<string[]>(spec.input_keys);
   const [llm, setLLM] = useState<string>(spec.llm_key);
 
   const formatReducer = useMemo(() => new FormatReducer(

--- a/app/src/contexts/ChainSpecContext.tsx
+++ b/app/src/contexts/ChainSpecContext.tsx
@@ -53,13 +53,13 @@ export const ChainSpecProvider: React.FC<ChainSpecProviderProps> = ({ children }
   const { LLMsNeedSave } = useContext(LLMContext);
   const [chainName, setChainName] = useState<string>("");
 
-  // The chainSpec is what we expect the revisions spect to be in the database.
+  // The chainSpec is what we expect the revision's spec to be in the database.
   // It is only updated after a load or a successful save. It is maintained
   // to determine whether the UI is in sync with the database.
   const [chainSpec, setChainSpec] = useState<ChainSpec | null>(null);
 
   // The displaySpec is used to populate the UI. It is updated whenever chainSpec
-  // is updated or when there is a structural chance to the spec (insertions and deletions).
+  // is updated or when there is a structural change to the spec (insertions and deletions).
   const [displaySpec, setDisplaySpec] = useState<ChainSpec | null>(null);
 
   // Dirty spec receives all updates to the spec from the UI (ie. onchange events)


### PR DESCRIPTION
Fixes #26

## Problem

This PR addresses two problems. The first is that inserting or deleting chains would put the UI into the `readyToInteract` state even though the displayed chain spec was not consistent with the chain in the database. This is because we're using a deep equals comparison of the `dirtyChainSpec` with the `chainSpec` to determine if we're ready to interact on the assumption that the `chainSpec` is consistent with what is saved on the server. Insertions or deletions updated both the `chainSpec` and `dirtyChainSpec` in order to generate or remove UI, but the side effect was to make them equal, thus putting the UI in the ready to interact state. The solution is to introduce a third version of the spec, `displaySpec` that plays the role `chainSpec` used to play in UI generation, so that `chainSpec` remains consistent with the server version.

The second problem is issue #26 where loading a (usually more complicated chain) does not always put the UI in the ready to interact state. I observed the problem was caused by failing to initialized input keys for at least one nested LLM chain spec. There is some pretty complicated update and timing issues involved here, so I could not determine the exact mechanism, but I did notice that the `variables` state was not being initialized with the `spec.input_keys` even though that's a reasonable thing to do. This initialization appears to fix the problem consistently, so I'm going to call this done until we see it again.

I am hopeful that this solution addresses issue #24 as well, but I haven't done enough testing to feel confident closing that issue. If we don't see it for a while, we should consider closing it.

## Solution

1. Initialize `variables` with `spec.input_keys` in LLMSpecDesigner to prevent initial state where 'dirtyChainSpec' fails to match 'chainSpec' (thus preventing putting the UI into readyToInteract state).
2. Introduce `displayChainSpec` in ChainContext that drives the UI, leaving `chainSpec` clean to use as our server chain spec reference.
3. Fix an issue where `findChainInCurrentSpec` callback incorrectly depended on `chainSpec` instead of `dirtyChainSpec`. It's unclear if this was causing problems, but correcting it can't hurt.
