### PR TITLE
Changed default repo_id to "google/flan-t5-xxl"

### DIFF
--- a/app/src/contexts/LLMContext.tsx
+++ b/app/src/contexts/LLMContext.tsx
@@ -89,7 +89,7 @@ export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => 
       case "huggingface_hub":
         return {
           _type: "huggingface_hub",
-          repo_id: "google/flan-t5-xl",
+          repo_id: "google/flan-t5-xxl",
           task: null,
           model_kwargs: {
             temperature: 0.8,


### PR DESCRIPTION
Fixes #36

## Problem

The default repo_id for Hugging Face LLMs, "google/flan-t5-xl" is no longer responsive.

## Solution

1.  Changed the default to "google/flan-t5-xxl" which is responsive.