### PR TITLE
Include the lib folder in the tests so they can run properly

### DIFF
--- a/lib/conftest.py
+++ b/lib/conftest.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+# Add the 'lib' directory to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))


### PR DESCRIPTION
Fixes pytest not working on my local environment

## Problem
When running pytest, get an error stating "ModuleNotFoundError: No module named 'lib'" preventing the tests from running

## Solution
Add a file named conftest.py to the lib directory in which the current running directory is added to the PATH variable for running the tests