### PR TITLE
add scsv and pickle files processing scripts

### DIFF
--- a/scripts/csv_to_json.py
+++ b/scripts/csv_to_json.py
@@ -4,10 +4,12 @@ import json
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 
 parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
-# parser.add_argument("-f", "--file", help="csv file to read from")
 
 args = vars(parser.parse_args())
 
+# Parse CSV to JSON
+# Input: CSV file with header containing 'sentences' and 'section_time_stamp'
+# Output: JSON file with sentences in 'text' field and timestamp in 'meta.section' field.
 def main(args):
   data = csv.DictReader(sys.stdin)
   records = [{

--- a/scripts/csv_to_json.py
+++ b/scripts/csv_to_json.py
@@ -1,0 +1,21 @@
+import csv
+import sys
+import json
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+
+parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+# parser.add_argument("-f", "--file", help="csv file to read from")
+
+args = vars(parser.parse_args())
+
+def main(args):
+  data = csv.DictReader(sys.stdin)
+  records = [{
+    'text': row['sentences'],
+    'meta': {
+      'section': row['section_time_stamp'],
+    }
+  } for row in data]
+  json.dump(records, sys.stdout)
+
+main(args)

--- a/scripts/pickle_to_json.py
+++ b/scripts/pickle_to_json.py
@@ -1,0 +1,49 @@
+import pandas as pd
+import pinecone
+import uuid
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+
+parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+parser.add_argument("-k", "--api_key", type=str, help="API Key for Pinecone")
+parser.add_argument("-emb", "--embedding_file", help="File location for embeddings (must be .pkl file)")
+
+args = vars(parser.parse_args())
+
+def createUUID():
+    return str(uuid.uuid4())
+
+## Main Function ##
+def main(args):
+    pinecone.init(api_key=args["api_key"], environment="northamerica-northeast1-gcp")
+    embedding_filepath = args["embedding_file"]
+
+    df_emb = pd.read_pickle(embedding_filepath)
+
+    print(df_emb.to_json())
+
+  
+  
+
+
+
+
+
+    # top_hits = retrieve_relevant_answer(input_question, df_emb, num_hits, embed_model, embed_encoder, max_tokens)
+
+    # if not json_output_flag:
+    #     # retrieve best question and answer TODO: Make it so we can retrieve many examples
+    #     top_question = top_hits["questions"].iloc[0]
+    #     top_answer = top_hits["answers"].iloc[0]
+
+    #     # Create question prompt
+    #     prompt = question_boiler.format(top_question, top_answer, input_question)
+
+    #     ans = run_gpt(openai_model, system_boiler, prompt, temp, max_tokens, max_tokens_output)
+    #     return print(ans)
+    # else:
+    #     if output_file_location:
+    #         return top_hits.head(num_hits).to_json(output_file_location)
+    #     else:
+    #         return(print(top_hits.head(num_hits).to_json()))
+
+main(args)

--- a/scripts/pickle_to_json.py
+++ b/scripts/pickle_to_json.py
@@ -21,29 +21,4 @@ def main(args):
 
     print(df_emb.to_json())
 
-  
-  
-
-
-
-
-
-    # top_hits = retrieve_relevant_answer(input_question, df_emb, num_hits, embed_model, embed_encoder, max_tokens)
-
-    # if not json_output_flag:
-    #     # retrieve best question and answer TODO: Make it so we can retrieve many examples
-    #     top_question = top_hits["questions"].iloc[0]
-    #     top_answer = top_hits["answers"].iloc[0]
-
-    #     # Create question prompt
-    #     prompt = question_boiler.format(top_question, top_answer, input_question)
-
-    #     ans = run_gpt(openai_model, system_boiler, prompt, temp, max_tokens, max_tokens_output)
-    #     return print(ans)
-    # else:
-    #     if output_file_location:
-    #         return top_hits.head(num_hits).to_json(output_file_location)
-    #     else:
-    #         return(print(top_hits.head(num_hits).to_json()))
-
 main(args)

--- a/scripts/pickle_to_json.py
+++ b/scripts/pickle_to_json.py
@@ -1,6 +1,4 @@
 import pandas as pd
-import pinecone
-import uuid
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 
 parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
@@ -9,12 +7,8 @@ parser.add_argument("-emb", "--embedding_file", help="File location for embeddin
 
 args = vars(parser.parse_args())
 
-def createUUID():
-    return str(uuid.uuid4())
-
-## Main Function ##
+## Parse pickle file to JSON for further processing
 def main(args):
-    pinecone.init(api_key=args["api_key"], environment="northamerica-northeast1-gcp")
     embedding_filepath = args["embedding_file"]
 
     df_emb = pd.read_pickle(embedding_filepath)


### PR DESCRIPTION
## Problem

While working on the VectorSearchChain I created some scripts to handle the [file format] -> json -> embeddings -> pinecone workflow. I neglected to check in the scripts that handle csv -> json and pickel -> json conversion. These scripts are meant for local data processing and should not be considered production ready.

## Solution

1. Add missing scripts
