### PR TITLE
Chat model

### DIFF
--- a/app/src/components/EditLLMs.tsx
+++ b/app/src/components/EditLLMs.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { LLMContext } from "../contexts/LLMContext";
-import { HuggingFaceHubLLM, LLM, OpenAILLM } from "../model/llm";
+import { HuggingFaceHubLLM, LLM, OpenAILLM, ChatOpenAILLM } from "../model/llm";
 import "./style/EditLLMs.scss";
 import QuickMenu from "./QuickMenu";
 
@@ -152,6 +152,67 @@ const HuggingFaceLLMEditor = ({ llmKey, llm, updateLLM }: HuggingFaceHubLLMEdito
   );
 }
 
+export interface ChatOpenAILLMEditorProps {
+  llmKey: string,
+  llm: ChatOpenAILLM
+  updateLLM: (llmKey: string, llm: LLM) => void
+}
+
+const ChatOpenAILLMEditor = ({ llmKey, llm, updateLLM }: ChatOpenAILLMEditorProps) => {
+  const [name, setName] = useState(llmKey);
+  const [modelName, setModelName] = useState(llm.model_name);
+  const [temperature, setTemperature] = useState<number>(llm.temperature);
+  const [maxTokens, setMaxTokens] = useState<number>(llm.max_tokens);
+
+  useEffect((): void => {
+    updateLLM(name, {
+      llm_type: 'chat_openai',
+      model_name: modelName,
+      temperature: temperature,
+      max_tokens: maxTokens,
+      n: 1,
+      request_timeout: null,
+    });
+  }, [name, modelName, temperature, maxTokens]);
+
+  useEffect((): void => {
+    setName(llmKey);
+    setModelName(llm.model_name);
+    setTemperature(llm.temperature);
+    setMaxTokens(llm.max_tokens);
+  }, [llm]);
+
+  useEffect((): void => {
+    setName(llmKey);
+  }, [llmKey]);
+
+  return (
+    <div className="llm">
+      <div className="llm-key">
+        <input type="text" className="llm-key-input"
+          defaultValue={name} onChange={(e) => setName(e.target.value)} />
+      </div>
+      <div className="llm-params">
+        <div className="llm-param">
+          <div className="llm-param-name">model name</div>
+          <input type="text" className="llm-param-value"
+            defaultValue={modelName} onChange={(e) => setModelName(e.target.value)} />
+        </div>
+        <div className="llm-param">
+          <div className="llm-param-name">temperature</div>
+          <input type="text" className="llm-param-value"
+            defaultValue={temperature} onChange={(e) => setTemperature(parseFloat(e.target.value))} />
+        </div>
+        <div className="llm-param">
+          <div className="llm-param-name">max tokens</div>
+          <input type="text" className="llm-param-value"
+            defaultValue={maxTokens} onChange={(e) => setMaxTokens(parseFloat(e.target.value))} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 const EditLLMs = () => {
   const { llms, addLLM, updateLLM, latestLLMs, isEditingLLMs,  setIsEditingLLMs } = useContext(LLMContext);
   const backgroundRef = useRef<HTMLDivElement>(null);
@@ -189,10 +250,12 @@ const EditLLMs = () => {
             return <OpenAILLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
           } else if (llm.llm_type === 'huggingface_hub') {
             return <HuggingFaceLLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
+          } else if (llm.llm_type == 'chat_openai') {
+            return <ChatOpenAILLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
           }
         })}
         <div className="llm-actions">
-          <QuickMenu modalKey="add-llm-menu" selectValue={addLLM} options={{ openai: 'Open AI', huggingface_hub: 'Hugging Face' }} />
+          <QuickMenu modalKey="add-llm-menu" selectValue={addLLM} options={{ openai: 'Open AI', huggingface_hub: 'Hugging Face', chat_openai: "Chat GPT" }} />
         </div>
       </div>
     </div>

--- a/app/src/contexts/LLMContext.tsx
+++ b/app/src/contexts/LLMContext.tsx
@@ -96,6 +96,15 @@ export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => 
             max_length: 256
           },
         }
+      case "chat_openai":
+        return {
+          llm_type: "chat_openai",
+          model_name: "gpt-3.5-turbo",
+          temperature: 0.7,
+          max_tokens: 256,
+          n: 1,
+          request_timeout: null,
+        }
     }
     throw new Error(`Unknown LLM type: ${llmType}`);
   };

--- a/app/src/model/llm.ts
+++ b/app/src/model/llm.ts
@@ -24,7 +24,16 @@ export interface HuggingFaceHubLLM {
   model_kwargs: HuggingFaceHubArgs;
 }
 
-export type LLM = OpenAILLM | HuggingFaceHubLLM;
+export interface ChatOpenAILLM {
+  llm_type: "chat_openai";
+  model_name: string;
+  temperature: number;
+  max_tokens: number;
+  n: number;
+  request_timeout: number | null;
+}
+
+export type LLM = OpenAILLM | HuggingFaceHubLLM | ChatOpenAILLM;
 
 export const defaultLLMs: Record<string, LLM> = {
   llm: {

--- a/lib/model/chain_revision.py
+++ b/lib/model/chain_revision.py
@@ -5,6 +5,7 @@ from pydantic_mongo import AbstractRepository, ObjectIdField
 from lib.model.chain_spec import ChainSpec, APIChainSpec, SequentialChainSpec, LLMChainSpec, CaseChainSpec, ReformatChainSpec, TransformChainSpec, VectorSearchChainSpec
 from lib.model.llm_spec import LLMSpec, OpenAILLMSpec, HuggingFaceHubLLMSpec, ChatOpenAILLMSpec
 
+
 def dump_json(obj: object, **kwargs):
   obj['id'] = str(obj['id']) if obj['id'] is not None else None
   obj['parent'] = str(obj['parent']) if obj['parent'] is not None else None
@@ -17,12 +18,12 @@ class ChainRevision(BaseModel):
   chain: ChainSpec
   llms: Dict[str, LLMSpec]
 
-
   class Config:
     json_encoders = {
       ObjectIdField: str,
     }
     json_dumps = dump_json
+
 
 ChainRevision.update_forward_refs()
 
@@ -30,6 +31,7 @@ ChainRevision.update_forward_refs()
 class ChainRevisionRepository(AbstractRepository[ChainRevision]):
   class Meta:
     collection_name = 'chain_revisions'
+
 
 def find_ancestor_ids(revision_id: ObjectIdField, repository: ChainRevisionRepository) -> list[ObjectIdField]:
   revision = repository.find_one_by_id(revision_id)

--- a/lib/model/chain_revision.py
+++ b/lib/model/chain_revision.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 from pydantic import BaseModel
 from pydantic_mongo import AbstractRepository, ObjectIdField
 from lib.model.chain_spec import ChainSpec, APIChainSpec, SequentialChainSpec, LLMChainSpec, CaseChainSpec, ReformatChainSpec, TransformChainSpec, VectorSearchChainSpec
-from lib.model.llm_spec import LLMSpec, OpenAILLMSpec, HuggingFaceHubLLMSpec
+from lib.model.llm_spec import LLMSpec, OpenAILLMSpec, HuggingFaceHubLLMSpec, ChatOpenAILLMSpec
 
 def dump_json(obj: object, **kwargs):
   obj['id'] = str(obj['id']) if obj['id'] is not None else None

--- a/lib/model/lang_chain_context.py
+++ b/lib/model/lang_chain_context.py
@@ -1,13 +1,13 @@
 from typing import Dict
 from pydantic import BaseModel
-from langchain.llms.base import BaseLLM
+from langchain.schema.language_model import BaseLanguageModel
 from lib.model.result import Result
 from datetime import datetime
 
 
 # provides context for generating lang chains including llms and prompts
 class LangChainContext(BaseModel):
-  llms: Dict[str, BaseLLM]
+  llms: Dict[str, BaseLanguageModel]
 
   verbose: bool = False
   recording: bool = False

--- a/lib/model/llm_spec.py
+++ b/lib/model/llm_spec.py
@@ -64,4 +64,4 @@ class ChatOpenAILLMSpec(BaseLLMSpec):
 
   def to_llm(self) -> LLM:
     return ChatOpenAI(model_name=self.model_name, temperature=self.temperature,
-                            max_tokens=self.max_tokens, n=self.n, request_timeout=self.request_timeout)
+                      max_tokens=self.max_tokens, n=self.n, request_timeout=self.request_timeout)

--- a/lib/model/llm_spec.py
+++ b/lib/model/llm_spec.py
@@ -3,10 +3,12 @@ from pydantic import BaseModel, Field
 from langchain.llms.base import LLM
 from langchain.llms.openai import OpenAI
 from langchain.llms.huggingface_hub import HuggingFaceHub
+from langchain.chat_models.openai import ChatOpenAI
 
 LLMSpec = Annotated[Union[
   "OpenAILLMSpec",
-  "HuggingFaceHubLLMSpec"
+  "HuggingFaceHubLLMSpec",
+  "ChatOpenAILLMSpec",
   ], Field(discriminator='llm_type')]
 
 
@@ -38,7 +40,6 @@ class OpenAILLMSpec(BaseLLMSpec):
                   request_timeout=self.request_timeout, logit_bias=self.logit_bias)
 
 
-
 class HuggingFaceHubLLMSpec(BaseLLMSpec):
   class ModelKwargs(TypedDict):
     temperature: float
@@ -51,3 +52,16 @@ class HuggingFaceHubLLMSpec(BaseLLMSpec):
 
   def to_llm(self) -> LLM:
     return HuggingFaceHub(model_kwargs=self.model_kwargs, repo_id=self.repo_id, task=self.task)
+
+
+class ChatOpenAILLMSpec(BaseLLMSpec):
+  llm_type: Literal["chat_openai"] = "chat_openai"
+  model_name: str
+  temperature: float
+  max_tokens: int
+  n: int
+  request_timeout: Optional[int]
+
+  def to_llm(self) -> LLM:
+    return ChatOpenAI(model_name=self.model_name, temperature=self.temperature,
+                            max_tokens=self.max_tokens, n=self.n, request_timeout=self.request_timeout)


### PR DESCRIPTION
## Problem
Adds in the ability to select and use a ChatGPT instance from ChatOpenAI as an llm in a langchain.

## Solution

- Adds ChatOpenAI as an LLM Option in both the front and backend
- Sets the default values for ChatOpenAI
- Modifies LangChainContext to use BaseLanguageModel instead of BaseLLM as this will also include chat_models.
- Wrote a new frontend editor for when the user adds a ChatOpenAI to the list of LLMs
- Minor line spacing fixes