### PR TITLE
The comparison of the dirtyLLMs was not working when keys were in different orders

### DIFF
--- a/app/src/contexts/LLMContext.tsx
+++ b/app/src/contexts/LLMContext.tsx
@@ -38,17 +38,34 @@ const areLLMDirtyLLMEqual = (llms: Record<string, any>, dirtyLLMs: Record<string
       return false;
   }
 
-  // Check if every key-value in obj1 is the same as obj2
   return keys1.every(key => {
       if (!(key in dirtyLLMs)) {
           return false;
       }
 
-      // Here, we are checking for nested objects. If the value is an object, we will do a recursive check.
-      // If not, just compare the values directly.
-      if (typeof llms[key] === 'object' && llms[key] !== null && typeof dirtyLLMs[key] === 'object' && dirtyLLMs[key] !== null) {
+      // compare array values
+      if (Array.isArray(llms[key]) && Array.isArray(dirtyLLMs[key])) {
+        if (llms[key].length !== dirtyLLMs[key].length) {
+          return false;
+        }
+
+        for (let i = 0; i < llms[key].length; i++) {
+          if (typeof llms[key][i] === 'object' && llms[key][i] !== null) {
+            if (!areLLMDirtyLLMEqual(llms[key][i], dirtyLLMs[key][i])) {
+              return false;
+            }
+          } else if (llms[key][i] !== dirtyLLMs[key][i]) {
+            return false;
+          }
+        }
+        return true;
+      }
+      // compare object values
+      else if (typeof llms[key] === 'object' && llms[key] !== null && typeof dirtyLLMs[key] === 'object' && dirtyLLMs[key] !== null) {
           return areLLMDirtyLLMEqual(llms[key], dirtyLLMs[key]);
-      } else {
+      }
+      // compare primitives
+      else {
           return llms[key] === dirtyLLMs[key];
       }
   });

--- a/app/src/contexts/LLMContext.tsx
+++ b/app/src/contexts/LLMContext.tsx
@@ -30,6 +30,30 @@ export interface LLMProviderProps {
   children: React.ReactNode;
 }
 
+const areLLMDirtyLLMEqual = (llms: Record<string, any>, dirtyLLMs: Record<string, any>): boolean => {
+  const keys1 = Object.keys(llms);
+  const keys2 = Object.keys(dirtyLLMs);
+  
+  if (keys1.length !== keys2.length) {
+      return false;
+  }
+
+  // Check if every key-value in obj1 is the same as obj2
+  return keys1.every(key => {
+      if (!(key in dirtyLLMs)) {
+          return false;
+      }
+
+      // Here, we are checking for nested objects. If the value is an object, we will do a recursive check.
+      // If not, just compare the values directly.
+      if (typeof llms[key] === 'object' && llms[key] !== null && typeof dirtyLLMs[key] === 'object' && dirtyLLMs[key] !== null) {
+          return areLLMDirtyLLMEqual(llms[key], dirtyLLMs[key]);
+      } else {
+          return llms[key] === dirtyLLMs[key];
+      }
+  });
+}
+
 export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => {
   const [llms, setLLMs] = useState<Record<string, LLM>>(defaultLLMs);
   const [dirtyLLMs, setDirtyLLMs] = useState<Record<string, LLM>>({});
@@ -51,7 +75,7 @@ export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => 
   }
 
   useEffect(() => {
-    setLLMsNeedSave(JSON.stringify(llms) !== JSON.stringify(dirtyLLMs));
+    setLLMsNeedSave(!areLLMDirtyLLMEqual(llms, dirtyLLMs));
   }, [llms, dirtyLLMs]);
 
   const deleteLLM = (name: string): void => {


### PR DESCRIPTION
Fixes #49 

## Problem
There was a bug where loading a chain would not put it in the readyForInteracting state. This was caused by the keys between the llms and dirtyLLMs being in different order.

## Solution
I wrote a method that dynamically looks at the keys in both objects and makes sure they have the same values for those keys.