### PR TITLE
Modifies how/when dirtyLLMs update the clean LLMs

### DIFF
--- a/app/src/components/EditLLMs.tsx
+++ b/app/src/components/EditLLMs.tsx
@@ -214,7 +214,7 @@ const ChatOpenAILLMEditor = ({ llmKey, llm, updateLLM }: ChatOpenAILLMEditorProp
 }
 
 const EditLLMs = () => {
-  const { llms, addLLM, updateLLM, latestLLMs, isEditingLLMs,  setIsEditingLLMs } = useContext(LLMContext);
+  const { llms, addLLM, updateLLM, isEditingLLMs,  setIsEditingLLMs } = useContext(LLMContext);
   const backgroundRef = useRef<HTMLDivElement>(null);
   const [visibilityState, setVisibilityState] = useState("absent");
 
@@ -229,9 +229,8 @@ const EditLLMs = () => {
   }, [isEditingLLMs, visibilityState]);
 
   const closeModal = useCallback(() => {
-    latestLLMs(); // ensure latest changes are available in context
     setIsEditingLLMs(false);
-  }, [setIsEditingLLMs, latestLLMs]);
+  }, [setIsEditingLLMs]);
 
   return (
     <div className={`edit-llms ${visibilityState}`}

--- a/app/src/contexts/LLMContext.tsx
+++ b/app/src/contexts/LLMContext.tsx
@@ -98,7 +98,7 @@ export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => 
   const deleteLLM = (name: string): void => {
     const newLLMs = {...llms};
     delete newLLMs[name];
-    setBothLLMs(newLLMs);
+    setDirtyLLMs(newLLMs);
   }
 
   const latestLLMs = (): Record<string, LLM> => {
@@ -106,7 +106,7 @@ export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => 
     return dirtyLLMs;
   }
 
-  const addLLM = (llmType: string) => (setBothLLMs({
+  const addLLM = (llmType: string) => (setDirtyLLMs({
     ...dirtyLLMs,
     [`llm-${Object.keys(dirtyLLMs).length}`]: defaultLLM(llmType),
   }));
@@ -152,7 +152,7 @@ export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => 
 
   return (
     <LLMContext.Provider value={{ 
-      llms,
+      llms: dirtyLLMs,
       addLLM,
       updateLLM,
       deleteLLM,


### PR DESCRIPTION
Fixes #25 

## Problem
Whenever a user was modifying the LLMs for a given chain, the llmsNeedSave was not working properly, so the readyToInteract state was still set to true.

## Solution

Inside the LLMContext, I modified all of the CRUD operations to only modify the dirty llms and then only allow the clean llms to be updated with the dirty llms when the user actually hits save