### PR TITLE
revert erroneous change to huggingface embedding key

### DIFF
--- a/app/src/components/designers/VectorSearchSpecDesigner.tsx
+++ b/app/src/components/designers/VectorSearchSpecDesigner.tsx
@@ -73,7 +73,7 @@ const VectorSearchSpecDesigner = ({ spec }: VectorSearchSpecDesignerProps) => {
         <label>Embed&nbsp;Engine</label>
         <select value={embeddingEngine} onChange={e => setEmbeddingEngine(e.target.value)}>
         <option key="openai" value="openai">openai</option>
-        <option key="hugging_face_llm" value="hugging_face_llm">huggingface</option>
+        <option key="huggingface" value="huggingface">huggingface</option>
         </select>
       </div>
       <div className="form-element">


### PR DESCRIPTION
## Problem

When the keys to the completion LLMs were modified, the huggingface key in the VectorSearchSpecDesigner was also modified, though the key had not been changed in the underlying chain (in LangChain, completion or chat LLMs and embedding LLMs are separate classes). This PR reverts that change so we can create working VectorSearchChains with Huggingface embeddings.

## Solution

1. Revert key.
