### PR TITLE
Remove best_of from llm_spec

### DIFF
--- a/app/src/components/EditLLMs.tsx
+++ b/app/src/components/EditLLMs.tsx
@@ -28,7 +28,6 @@ const OpenAILLMEditor = ({ llmKey, llm, updateLLM }: OpenAILLMEditorProps) => {
       frequency_penalty: frequencyPenalty,
       presence_penalty: presencePenalty,
       n: 1,
-      best_of: 1,
       request_timeout: null,
       logit_bias: {},
       llm_type: 'openai',

--- a/app/src/contexts/LLMContext.tsx
+++ b/app/src/contexts/LLMContext.tsx
@@ -123,7 +123,6 @@ export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => 
           frequency_penalty: 0.0,
           presence_penalty: 0.0,
           n: 1,
-          best_of: 1,
           request_timeout: null,
           logit_bias: {}
         }

--- a/app/src/model/llm.ts
+++ b/app/src/model/llm.ts
@@ -7,7 +7,6 @@ export interface OpenAILLM {
   frequency_penalty: number;
   presence_penalty: number;
   n: number;
-  best_of: number;
   request_timeout: number | null;
   logit_bias: Record<number, number>;
 }
@@ -45,7 +44,6 @@ export const defaultLLMs: Record<string, LLM> = {
     "frequency_penalty": 0.0,
     "presence_penalty": 0.0,
     "n": 1,
-    "best_of": 1,
     "request_timeout": null,
     "logit_bias": {},
   }

--- a/lib/model/llm_spec.py
+++ b/lib/model/llm_spec.py
@@ -29,14 +29,13 @@ class OpenAILLMSpec(BaseLLMSpec):
   frequency_penalty: float
   presence_penalty: float
   n: int
-  best_of: int
   request_timeout: Optional[int]
   logit_bias: Optional[Dict[int, int]]
 
   def to_llm(self) -> LLM:
     return OpenAI(model_name=self.model_name, temperature=self.temperature,
                   max_tokens=self.max_tokens, top_p=self.top_p, frequency_penalty=self.frequency_penalty,
-                  presence_penalty=self.presence_penalty, n=self.n, best_of=self.best_of,
+                  presence_penalty=self.presence_penalty, n=self.n,
                   request_timeout=self.request_timeout, logit_bias=self.logit_bias)
 
 

--- a/lib/model/tests/test_chain_revision.py
+++ b/lib/model/tests/test_chain_revision.py
@@ -9,7 +9,7 @@ def test_chain_revision_serialization():
     os.environ["OPENAI_API_KEY"] = "set me!"
 
   llm = OpenAILLMSpec(model_name="davinci", temperature=0.5, max_tokens=10, top_p=1.0, frequency_penalty=0.0,
-                      presence_penalty=0.0, n=1, best_of=1, request_timeout=10, logit_bias=None)
+                      presence_penalty=0.0, n=1, request_timeout=10, logit_bias=None)
 
   chain_revision = ChainRevision(
       chain_id=1,

--- a/lib/model/tests/test_llm_spec.py
+++ b/lib/model/tests/test_llm_spec.py
@@ -3,7 +3,7 @@ from model.llm_spec import OpenAILLMSpec
 
 def test_llm_spec_serialization():
   llm = OpenAILLMSpec(model_name="davinci", temperature=0.5, max_tokens=10, top_p=1.0, frequency_penalty=0.0,
-                      presence_penalty=0.0, n=1, best_of=1, request_timeout=10, logit_bias=None)
+                      presence_penalty=0.0, n=1, request_timeout=10, logit_bias=None)
 
   serialized = llm.json()
   deserialized = OpenAILLMSpec.parse_raw(serialized)


### PR DESCRIPTION
## Problem

When trying to load in coverage-oracle-2, there was an issue with the best_of field in the llm_spec.

## Solution

Best_of spec is not a necessary or currently used field, therefore it has been removed from the spec