### PR TITLE
Use CTransformers To Enable Local Huggingface LLMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ node_modules
 /.vs
 /.idea
 /docker-envs/*.env
+/lib/local/models/*
 /mongo-data/.mongodb/mongosh
 /mongo-data

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ venv
 testbench.egg-info
 node_modules
 /.vs
+/.idea
 /docker-envs/*.env
 /mongo-data/.mongodb/mongosh
 /mongo-data

--- a/app/src/components/EditLLMs.tsx
+++ b/app/src/components/EditLLMs.tsx
@@ -253,7 +253,7 @@ const EditLLMs = () => {
           }
         })}
         <div className="llm-actions">
-          <QuickMenu modalKey="add-llm-menu" selectValue={addLLM} options={{ openai: 'Open AI', huggingface_hub: 'Hugging Face', chat_openai: "Chat GPT" }} />
+          <QuickMenu modalKey="add-llm-menu" selectValue={addLLM} options={{ openai: 'Open AI', huggingface_hub: 'Hugging Face', huggingface_hub_local: 'Hugging Face Local', chat_openai: "Chat GPT" }} />
         </div>
       </div>
     </div>

--- a/app/src/components/EditLLMs.tsx
+++ b/app/src/components/EditLLMs.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { LLMContext } from "../contexts/LLMContext";
-import {HuggingFaceHubLLM, LLM, OpenAILLM, ChatOpenAILLM, HuggingFaceHubLocalLLM} from "../model/llm";
+import {HuggingFaceHubLLM, LLM, OpenAILLM, ChatOpenAILLM, CTransformersLLM } from "../model/llm";
 import "./style/EditLLMs.scss";
 import QuickMenu from "./QuickMenu";
 
@@ -151,13 +151,13 @@ const HuggingFaceLLMEditor = ({ llmKey, llm, updateLLM }: HuggingFaceHubLLMEdito
   );
 }
 
-export interface HuggingFaceHubLocalLLMEditorProps {
+export interface CTransformersLLMEditorProps {
   llmKey: string,
-  llm: HuggingFaceHubLocalLLM,
+  llm: CTransformersLLM,
   updateLLM: (llmKey: string, llm: LLM) => void
 }
 
-const HuggingFaceLocalLLMEditor = ({ llmKey, llm, updateLLM }: HuggingFaceHubLocalLLMEditorProps) => {
+const CTransformersLLMEditor = ({ llmKey, llm, updateLLM }: CTransformersLLMEditorProps) => {
   const [name, setName] = useState(llmKey);
   const [repoId, setRepoId] = useState(llm.repo_id);
   const [temperature, setTemperature] = useState<number>(llm.model_kwargs.temperature);
@@ -165,7 +165,7 @@ const HuggingFaceLocalLLMEditor = ({ llmKey, llm, updateLLM }: HuggingFaceHubLoc
 
   useEffect((): void => {
     updateLLM(name, {
-      llm_type: 'huggingface_hub_local',
+      llm_type: 'ctransformers_llm',
       repo_id: repoId,
       task: null,
       model_kwargs: {
@@ -309,8 +309,8 @@ const EditLLMs = () => {
             return <OpenAILLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
           } else if (llm.llm_type === 'huggingface_hub') {
             return <HuggingFaceLLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
-          } else if (llm.llm_type === 'huggingface_hub_local') {
-            return <HuggingFaceLocalLLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
+          } else if (llm.llm_type === 'ctransformers_llm') {
+            return <CTransformersLLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
           } else if (llm.llm_type == 'chat_openai') {
             return <ChatOpenAILLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
           }

--- a/app/src/components/EditLLMs.tsx
+++ b/app/src/components/EditLLMs.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { LLMContext } from "../contexts/LLMContext";
-import { HuggingFaceHubLLM, LLM, OpenAILLM, ChatOpenAILLM } from "../model/llm";
+import {HuggingFaceHubLLM, LLM, OpenAILLM, ChatOpenAILLM, HuggingFaceHubLocalLLM} from "../model/llm";
 import "./style/EditLLMs.scss";
 import QuickMenu from "./QuickMenu";
 
@@ -151,6 +151,67 @@ const HuggingFaceLLMEditor = ({ llmKey, llm, updateLLM }: HuggingFaceHubLLMEdito
   );
 }
 
+export interface HuggingFaceHubLocalLLMEditorProps {
+  llmKey: string,
+  llm: HuggingFaceHubLocalLLM,
+  updateLLM: (llmKey: string, llm: LLM) => void
+}
+
+const HuggingFaceLocalLLMEditor = ({ llmKey, llm, updateLLM }: HuggingFaceHubLocalLLMEditorProps) => {
+  const [name, setName] = useState(llmKey);
+  const [repoId, setRepoId] = useState(llm.repo_id);
+  const [temperature, setTemperature] = useState<number>(llm.model_kwargs.temperature);
+  const [maxLength, setMaxLength] = useState<number>(llm.model_kwargs.max_length);
+
+  useEffect((): void => {
+    updateLLM(name, {
+      llm_type: 'huggingface_hub_local',
+      repo_id: repoId,
+      task: null,
+      model_kwargs: {
+        temperature: temperature,
+        max_length: maxLength
+      }
+    });
+  }, [name, repoId, temperature, maxLength]);
+
+  useEffect((): void => {
+    setRepoId(llm.repo_id);
+    setTemperature(llm.model_kwargs.temperature);
+    setMaxLength(llm.model_kwargs.max_length);
+  }, [llm]);
+
+  useEffect((): void => {
+    setName(llmKey);
+  }, [llmKey]);
+
+  return (
+    <div className="llm">
+      <div className="llm-key">
+        <input type="text" className="llm-key-input"
+          defaultValue={name} onChange={(e) => setName(e.target.value)} />
+      </div>
+      <div className="llm-params">
+        <div className="llm-param">
+          <div className="llm-param-name">repo id</div>
+          <input type="text" className="llm-param-value"
+            defaultValue={repoId} onChange={(e) => setRepoId(e.target.value)} />
+        </div>
+        <div className="llm-param">
+          <div className="llm-param-name">temperature</div>
+          <input type="text" className="llm-param-value"
+            defaultValue={temperature} onChange={(e) => setTemperature(parseFloat(e.target.value))} />
+        </div>
+        <div className="llm-param">
+          <div className="llm-param-name">max length</div>
+          <input type="text" className="llm-param-value"
+            defaultValue={maxLength} onChange={(e) => setMaxLength(parseFloat(e.target.value))} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export interface ChatOpenAILLMEditorProps {
   llmKey: string,
   llm: ChatOpenAILLM
@@ -248,6 +309,8 @@ const EditLLMs = () => {
             return <OpenAILLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
           } else if (llm.llm_type === 'huggingface_hub') {
             return <HuggingFaceLLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
+          } else if (llm.llm_type === 'huggingface_hub_local') {
+            return <HuggingFaceLocalLLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
           } else if (llm.llm_type == 'chat_openai') {
             return <ChatOpenAILLMEditor key={llmKey} llmKey={llmKey} llm={llm} updateLLM={(name, llm) => updateLLM(idx, name, llm)} />
           }

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -65,7 +65,6 @@ const Header = () => {
       throw new Error("No chain spec to save");
     }
     const llms = latestLLMs();
-
     const nextRevision = createRevision(revision, spec, llms);
     try {
       const nextRevisionId = await saveRevision(chainName, nextRevision);

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -5,6 +5,7 @@ import ChainSpecContext from "../contexts/ChainSpecContext";
 import { LLMContext } from "../contexts/LLMContext";
 import FilterMenu from "./FilterMenu";
 import TextModal from "./TextModal";
+import { defaultLLMs } from "../model/llm";
 import { setTimedMessage } from "../util/errorhandling";
 import "./style/Header.scss";
 import ImportChain from "./ImportChain";
@@ -43,6 +44,7 @@ const Header = () => {
     setErrorMessage(null);
     setChainName(name);
     setChainSpec(null);
+    setLLMs(defaultLLMs);
     setRevision(null);
   }
 

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -5,7 +5,6 @@ import ChainSpecContext from "../contexts/ChainSpecContext";
 import { LLMContext } from "../contexts/LLMContext";
 import FilterMenu from "./FilterMenu";
 import TextModal from "./TextModal";
-import { defaultLLMs } from "../model/llm";
 import { setTimedMessage } from "../util/errorhandling";
 import "./style/Header.scss";
 import ImportChain from "./ImportChain";
@@ -44,7 +43,6 @@ const Header = () => {
     setErrorMessage(null);
     setChainName(name);
     setChainSpec(null);
-    setLLMs(defaultLLMs);
     setRevision(null);
   }
 
@@ -65,6 +63,7 @@ const Header = () => {
       throw new Error("No chain spec to save");
     }
     const llms = latestLLMs();
+
     const nextRevision = createRevision(revision, spec, llms);
     try {
       const nextRevisionId = await saveRevision(chainName, nextRevision);

--- a/app/src/components/designers/LLMSpecDesigner.tsx
+++ b/app/src/components/designers/LLMSpecDesigner.tsx
@@ -58,7 +58,7 @@ const LLMSpecDesigner = ({ spec }: LLMSpecDesignerProps) => {
       <div className="form-element">
         <label>LLM</label>
         <select value={llm} onChange={e => setLLM(e.target.value)}>
-            {Object.keys(llms).map(llm => <option key={llm} value={llm}>{llm}</option>)}
+          {Object.keys(llms).map(llm => <option key={llm} value={llm}>{llm}</option>)}
         </select>
       </div>
       <div className="form-element">

--- a/app/src/components/designers/LLMSpecDesigner.tsx
+++ b/app/src/components/designers/LLMSpecDesigner.tsx
@@ -10,6 +10,7 @@ interface LLMSpecDesignerProps { spec: LLMSpec };
   
 const LLMSpecDesigner = ({ spec }: LLMSpecDesignerProps) => {
   const { llms } = useContext(LLMContext);
+  const { setIsEditingLLMs } = useContext(LLMContext);
   const { updateChainSpec, deleteChainSpec } = useContext(ChainSpecContext);
 
   const [prompt, setPrompt] = useState<string>(spec.prompt);
@@ -56,10 +57,18 @@ const LLMSpecDesigner = ({ spec }: LLMSpecDesignerProps) => {
         placeholder="Enter prompt here."
       />
       <div className="form-element">
-        <label>LLM</label>
-        <select value={llm} onChange={e => setLLM(e.target.value)}>
-          {Object.keys(llms).map(llm => <option key={llm} value={llm}>{llm}</option>)}
-        </select>
+        {
+          Object.keys(llms).length === 0 ? (
+            <button className="add-llm" onClick={() => setIsEditingLLMs(true)}>Add LLM</button>
+            ) : (
+              <div>
+                <label>LLM</label>
+                <select value={llm} onChange={e => setLLM(e.target.value)}>
+                  {Object.keys(llms).map(llm => <option key={llm} value={llm}>{llm}</option>)}
+                </select>
+              </div>
+          )
+        }
       </div>
       <div className="form-element">
         <label>Output Key</label>

--- a/app/src/components/designers/LLMSpecDesigner.tsx
+++ b/app/src/components/designers/LLMSpecDesigner.tsx
@@ -10,7 +10,6 @@ interface LLMSpecDesignerProps { spec: LLMSpec };
   
 const LLMSpecDesigner = ({ spec }: LLMSpecDesignerProps) => {
   const { llms } = useContext(LLMContext);
-  const { setIsEditingLLMs } = useContext(LLMContext);
   const { updateChainSpec, deleteChainSpec } = useContext(ChainSpecContext);
 
   const [prompt, setPrompt] = useState<string>(spec.prompt);
@@ -57,18 +56,10 @@ const LLMSpecDesigner = ({ spec }: LLMSpecDesignerProps) => {
         placeholder="Enter prompt here."
       />
       <div className="form-element">
-        {
-          Object.keys(llms).length === 0 ? (
-            <button className="add-llm" onClick={() => setIsEditingLLMs(true)}>Add LLM</button>
-            ) : (
-              <div>
-                <label>LLM</label>
-                <select value={llm} onChange={e => setLLM(e.target.value)}>
-                  {Object.keys(llms).map(llm => <option key={llm} value={llm}>{llm}</option>)}
-                </select>
-              </div>
-          )
-        }
+        <label>LLM</label>
+        <select value={llm} onChange={e => setLLM(e.target.value)}>
+            {Object.keys(llms).map(llm => <option key={llm} value={llm}>{llm}</option>)}
+        </select>
       </div>
       <div className="form-element">
         <label>Output Key</label>

--- a/app/src/components/style/Designer.scss
+++ b/app/src/components/style/Designer.scss
@@ -7,11 +7,6 @@
     padding-right: 35rem;
   }
 
-  .add-llm {
-    margin: 0px auto;
-    background-color: #3A7734;
-  }
-  
   .spec-designer {
     border: var(--standard-border);
     border-radius: var(--standard-border-radius);

--- a/app/src/components/style/Designer.scss
+++ b/app/src/components/style/Designer.scss
@@ -6,6 +6,11 @@
   &.interacting {
     padding-right: 35rem;
   }
+
+  .add-llm {
+    margin: 0px auto;
+    background-color: #3A7734;
+  }
   
   .spec-designer {
     border: var(--standard-border);

--- a/app/src/components/style/Designer.scss
+++ b/app/src/components/style/Designer.scss
@@ -6,7 +6,6 @@
   &.interacting {
     padding-right: 35rem;
   }
-
   .spec-designer {
     border: var(--standard-border);
     border-radius: var(--standard-border-radius);

--- a/app/src/contexts/LLMContext.tsx
+++ b/app/src/contexts/LLMContext.tsx
@@ -138,7 +138,7 @@ export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => 
         }
       case "huggingface_hub_local":
         return {
-          llm_type: "huggingface_hub",
+          llm_type: "huggingface_hub_local",
           repo_id: "TheBloke/Llama-2-13B-chat-GGML",
           model_type: "llama",
           task: null,

--- a/app/src/contexts/LLMContext.tsx
+++ b/app/src/contexts/LLMContext.tsx
@@ -136,9 +136,9 @@ export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => 
             max_length: 256
           },
         }
-      case "huggingface_hub_local":
+      case "ctransformers_llm":
         return {
-          llm_type: "huggingface_hub_local",
+          llm_type: "ctransformers_llm",
           repo_id: "TheBloke/Llama-2-13B-chat-GGML",
           model_type: "llama",
           task: null,

--- a/app/src/contexts/LLMContext.tsx
+++ b/app/src/contexts/LLMContext.tsx
@@ -136,6 +136,17 @@ export const LLMContextProvider: React.FC<LLMProviderProps> = ({ children }) => 
             max_length: 256
           },
         }
+      case "huggingface_hub_local":
+        return {
+          llm_type: "huggingface_hub",
+          repo_id: "TheBloke/Llama-2-13B-chat-GGML",
+          model_type: "llama",
+          task: null,
+          model_kwargs: {
+            temperature: 0.8,
+            max_length: 256
+          },
+        }
       case "chat_openai":
         return {
           llm_type: "chat_openai",

--- a/app/src/model/llm.ts
+++ b/app/src/model/llm.ts
@@ -25,7 +25,7 @@ export interface HuggingFaceHubLLM {
 
 export interface HuggingFaceHubLocalLLM {
   llm_type: "huggingface_hub_local";
-  model_type: string;
+  model_type?: string;
   repo_id: string;
   task: string | null;
   model_kwargs: HuggingFaceHubArgs;

--- a/app/src/model/llm.ts
+++ b/app/src/model/llm.ts
@@ -23,6 +23,14 @@ export interface HuggingFaceHubLLM {
   model_kwargs: HuggingFaceHubArgs;
 }
 
+export interface HuggingFaceHubLocalLLM {
+  llm_type: "huggingface_hub_local";
+  model_type: string;
+  repo_id: string;
+  task: string | null;
+  model_kwargs: HuggingFaceHubArgs;
+}
+
 export interface ChatOpenAILLM {
   llm_type: "chat_openai";
   model_name: string;
@@ -32,7 +40,7 @@ export interface ChatOpenAILLM {
   request_timeout: number | null;
 }
 
-export type LLM = OpenAILLM | HuggingFaceHubLLM | ChatOpenAILLM;
+export type LLM = OpenAILLM | HuggingFaceHubLLM | HuggingFaceHubLocalLLM |ChatOpenAILLM;
 
 export const defaultLLMs: Record<string, LLM> = {
   llm: {

--- a/app/src/model/llm.ts
+++ b/app/src/model/llm.ts
@@ -23,12 +23,17 @@ export interface HuggingFaceHubLLM {
   model_kwargs: HuggingFaceHubArgs;
 }
 
-export interface HuggingFaceHubLocalLLM {
-  llm_type: "huggingface_hub_local";
+export interface CTransformersLLMArgs {
+  temperature: number;
+  max_length: number;
+}
+
+export interface CTransformersLLM {
+  llm_type: "ctransformers_llm";
   model_type?: string;
   repo_id: string;
   task: string | null;
-  model_kwargs: HuggingFaceHubArgs;
+  model_kwargs: CTransformersLLMArgs;
 }
 
 export interface ChatOpenAILLM {
@@ -40,7 +45,7 @@ export interface ChatOpenAILLM {
   request_timeout: number | null;
 }
 
-export type LLM = OpenAILLM | HuggingFaceHubLLM | HuggingFaceHubLocalLLM |ChatOpenAILLM;
+export type LLM = OpenAILLM | HuggingFaceHubLLM | CTransformersLLM |ChatOpenAILLM;
 
 export const defaultLLMs: Record<string, LLM> = {
   llm: {

--- a/lib/local/huggingface_hub_local.py
+++ b/lib/local/huggingface_hub_local.py
@@ -1,0 +1,49 @@
+import os
+from typing import Any, List, Optional
+from langchain.callbacks.manager import CallbackManagerForLLMRun
+from langchain.llms.base import LLM
+from langchain.llms import CTransformers
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from langchain import PromptTemplate, LLMChain
+
+LOCAL_LLM = f"{os.getcwd()}/lib/local/models/llama-2-13b-chat.ggmlv3.q4_0.bin"
+
+
+class HuggingFaceHubLocal(LLM):
+    @property
+    def _llm_type(self) -> str:
+        """Return type of llm."""
+        return "huggingface_hub_local"
+
+    def _call(
+            self,
+            prompt: str,
+            stop: Optional[List[str]] = None,
+            run_manager: Optional[CallbackManagerForLLMRun] = None,
+            **kwargs: Any,
+    ) -> str:
+
+        llm = CTransformers(
+            model=LOCAL_LLM,
+            model_type="llama",
+            max_new_tokens=128,
+            temperature=0,
+        )
+
+        # Streaming
+        # response = llm(prompt)
+        #
+        # return response
+
+        #  LLMChain
+        template = """Question: {question}
+
+        Answer:"""
+
+        prompt = PromptTemplate(template=template, input_variables=["question"])
+
+        llm_chain = LLMChain(prompt=prompt, llm=llm)
+
+        response = llm_chain.run(prompt)
+
+        return response

--- a/lib/model/chain_revision.py
+++ b/lib/model/chain_revision.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 from pydantic import BaseModel
 from pydantic_mongo import AbstractRepository, ObjectIdField
 from lib.model.chain_spec import ChainSpec, APIChainSpec, SequentialChainSpec, LLMChainSpec, CaseChainSpec, ReformatChainSpec, TransformChainSpec, VectorSearchChainSpec
-from lib.model.llm_spec import LLMSpec, OpenAILLMSpec, HuggingFaceHubLLMSpec, ChatOpenAILLMSpec
+from lib.model.llm_spec import LLMSpec, OpenAILLMSpec, HuggingFaceHubLLMSpec, HuggingFaceHubLocalLLMSpec, ChatOpenAILLMSpec
 
 
 def dump_json(obj: object, **kwargs):

--- a/lib/model/llm_spec.py
+++ b/lib/model/llm_spec.py
@@ -8,6 +8,7 @@ from langchain.chat_models.openai import ChatOpenAI
 LLMSpec = Annotated[Union[
   "OpenAILLMSpec",
   "HuggingFaceHubLLMSpec",
+  "HuggingFaceHubLocalLLMSpec",
   "ChatOpenAILLMSpec",
   ], Field(discriminator='llm_type')]
 
@@ -45,6 +46,17 @@ class HuggingFaceHubLLMSpec(BaseLLMSpec):
     max_length: int
 
   llm_type: Literal["huggingface_hub"] = "huggingface_hub"
+  repo_id: str
+  task: Optional[str]
+  model_kwargs: Optional[ModelKwargs]
+
+
+class HuggingFaceHubLocalLLMSpec(BaseLLMSpec):
+  class ModelKwargs(TypedDict):
+    temperature: float
+    max_length: int
+
+  llm_type: Literal["huggingface_hub_local"] = "huggingface_hub_local"
   repo_id: str
   task: Optional[str]
   model_kwargs: Optional[ModelKwargs]

--- a/lib/model/llm_spec.py
+++ b/lib/model/llm_spec.py
@@ -4,75 +4,79 @@ from langchain.llms.base import LLM
 from langchain.llms.openai import OpenAI
 from langchain.llms.huggingface_hub import HuggingFaceHub
 from langchain.chat_models.openai import ChatOpenAI
+from lib.local.huggingface_hub_local import HuggingFaceHubLocal
 
 LLMSpec = Annotated[Union[
-  "OpenAILLMSpec",
-  "HuggingFaceHubLLMSpec",
-  "HuggingFaceHubLocalLLMSpec",
-  "ChatOpenAILLMSpec",
-  ], Field(discriminator='llm_type')]
+    "OpenAILLMSpec",
+    "HuggingFaceHubLLMSpec",
+    "HuggingFaceHubLocalLLMSpec",
+    "ChatOpenAILLMSpec",
+], Field(discriminator='llm_type')]
 
 
 class BaseLLMSpec(BaseModel):
-  def to_llm(self) -> LLM:
-    raise NotImplementedError
+    def to_llm(self) -> LLM:
+        raise NotImplementedError
 
-  def copy_replace(self, replace: Callable[[LLMSpec], LLMSpec]):
-    return replace(self).copy(deep=True)
+    def copy_replace(self, replace: Callable[[LLMSpec], LLMSpec]):
+        return replace(self).copy(deep=True)
 
 
 class OpenAILLMSpec(BaseLLMSpec):
-  llm_type: Literal["openai"] = "openai"
-  model_name: str
-  temperature: float
-  max_tokens: int
-  top_p: float
-  frequency_penalty: float
-  presence_penalty: float
-  n: int
-  request_timeout: Optional[int]
-  logit_bias: Optional[Dict[int, int]]
+    llm_type: Literal["openai"] = "openai"
+    model_name: str
+    temperature: float
+    max_tokens: int
+    top_p: float
+    frequency_penalty: float
+    presence_penalty: float
+    n: int
+    request_timeout: Optional[int]
+    logit_bias: Optional[Dict[int, int]]
 
-  def to_llm(self) -> LLM:
-    return OpenAI(model_name=self.model_name, temperature=self.temperature,
-                  max_tokens=self.max_tokens, top_p=self.top_p, frequency_penalty=self.frequency_penalty,
-                  presence_penalty=self.presence_penalty, n=self.n,
-                  request_timeout=self.request_timeout, logit_bias=self.logit_bias)
+    def to_llm(self) -> LLM:
+        return OpenAI(model_name=self.model_name, temperature=self.temperature,
+                      max_tokens=self.max_tokens, top_p=self.top_p, frequency_penalty=self.frequency_penalty,
+                      presence_penalty=self.presence_penalty, n=self.n,
+                      request_timeout=self.request_timeout, logit_bias=self.logit_bias)
 
 
 class HuggingFaceHubLLMSpec(BaseLLMSpec):
-  class ModelKwargs(TypedDict):
-    temperature: float
-    max_length: int
+    class ModelKwargs(TypedDict):
+        temperature: float
+        max_length: int
 
-  llm_type: Literal["huggingface_hub"] = "huggingface_hub"
-  repo_id: str
-  task: Optional[str]
-  model_kwargs: Optional[ModelKwargs]
+    llm_type: Literal["huggingface_hub"] = "huggingface_hub"
+    repo_id: str
+    task: Optional[str]
+    model_kwargs: Optional[ModelKwargs]
+
+    def to_llm(self) -> LLM:
+        return HuggingFaceHub(model_kwargs=self.model_kwargs, repo_id=self.repo_id, task=self.task)
 
 
 class HuggingFaceHubLocalLLMSpec(BaseLLMSpec):
-  class ModelKwargs(TypedDict):
-    temperature: float
-    max_length: int
+    class ModelKwargs(TypedDict):
+        temperature: float
+        max_length: int
 
-  llm_type: Literal["huggingface_hub_local"] = "huggingface_hub_local"
-  repo_id: str
-  task: Optional[str]
-  model_kwargs: Optional[ModelKwargs]
+    llm_type: Literal["huggingface_hub_local"] = "huggingface_hub_local"
+    repo_id: str
+    task: Optional[str]
+    model_kwargs: Optional[ModelKwargs]
 
-  def to_llm(self) -> LLM:
-    return HuggingFaceHub(model_kwargs=self.model_kwargs, repo_id=self.repo_id, task=self.task)
+    def to_llm(self) -> LLM:
+        return HuggingFaceHubLocal()
 
 
 class ChatOpenAILLMSpec(BaseLLMSpec):
-  llm_type: Literal["chat_openai"] = "chat_openai"
-  model_name: str
-  temperature: float
-  max_tokens: int
-  n: int
-  request_timeout: Optional[int]
+    llm_type: Literal["chat_openai"] = "chat_openai"
+    model_name: str
+    temperature: float
+    max_tokens: int
+    n: int
+    request_timeout: Optional[int]
 
-  def to_llm(self) -> LLM:
-    return ChatOpenAI(model_name=self.model_name, temperature=self.temperature,
-                      max_tokens=self.max_tokens, n=self.n, request_timeout=self.request_timeout)
+    def to_llm(self) -> LLM:
+        return ChatOpenAI(model_name=self.model_name, temperature=self.temperature,
+                          max_tokens=self.max_tokens, n=self.n, request_timeout=self.request_timeout)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ charset-normalizer==3.1.0
 click==8.1.3
 cliff==4.2.0
 cmd2==2.4.3
+ctransformers==0.2.26
 dataclasses-json==0.5.7
 dnspython==2.3.0
 exceptiongroup==1.1.1


### PR DESCRIPTION
This PR adds the following:

- We have a new CTransformers LLM option in the LLM interface. This option allows you to specify an LLM model from huggingface hub and model type in addition to the normal hyperparameters.
- We have the LLMSpec models on the front end and back end to configure, transport, save and instantiate CTransformers LangChain LLM within chains.
- Documentation on how to use this option in the README (or additional documentation page). I believe the testbench server will need to be run outside the docker container for this to work.