### PR TITLE
Remove PyTorch dependencies for deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,14 @@ docker-compose up
 ```
 
 URL is http://localhost:5173
+
+## Vector Search
+
+The vector search chain relies on SentenceTransformers which relies on PyTorch to run. This works well on Macs, but apparently not on Linux (Windows is an unkonwn). We've removed the PyTorch dependency by default so we can deploy on Linux. To regain vector search functionality uncomment:
+```
+# sentence-transformers==2.2.2 - uncomment for vector search
+# torch==2.0.1 - uncomment for vector search
+# torchvision==0.15.2 - uncomment for vector search
+# transformers==4.31.0 - uncomment for vector search
+```
+In requirements.txt before building (or install these packages manually).

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ requests-mock==1.10.0
 safetensors==0.3.1
 scikit-learn==1.3.0
 scipy==1.11.1
-sentence-transformers==2.2.2
+# sentence-transformers==2.2.2 - uncomment for vector search
 sentencepiece==0.1.99
 six==1.16.0
 SQLAlchemy==1.4.47
@@ -76,10 +76,10 @@ tenacity==8.2.2
 threadpoolctl==3.2.0
 tokenizers==0.13.3
 tomli==2.0.1
-torch==2.0.1
-torchvision==0.15.2
+# torch==2.0.1 - uncomment for vector search
+# torchvision==0.15.2 - uncomment for vector search
 tqdm==4.65.0
-transformers==4.31.0
+# transformers==4.31.0 - uncomment for vector search
 typing-inspect==0.8.0
 typing_extensions==4.5.0
 urllib3==1.26.15


### PR DESCRIPTION
## Problem

Testbench currently fails to deploy in cloud deployments because its pytorch dependency requires GPU. Pytorch (and a few packages related to it) are only required by vector search, so a temporary solution is to disable those packages by default.

## Solution

1. Remove vector search related packages.
2. Document it in the readme.
